### PR TITLE
Upgrade Realm to 12.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "promise-reflect": "^1.1.0",
         "react-native-uuid": "^2.0.1",
-        "realm": "^12.12.1"
+        "realm": "^12.13.1"
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",
@@ -15751,9 +15751,10 @@
       "peer": true
     },
     "node_modules/realm": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-12.12.1.tgz",
-      "integrity": "sha512-xkTnkrLqm9ihowzUR4cXQFccZliZ3CAgZ4opIOObEhXmVAftz2InPccmkXg8qOpU611asTpfRBHqEMM+3eJLYg==",
+      "version": "12.13.1",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-12.13.1.tgz",
+      "integrity": "sha512-fAs70ZCBf1P7htVhOTrDMFHD6SzoGXVsALy6DpOPR6t0LXoK635cKxBMECX3bYdCgI7+riSfdoWXLA/7g5yTSQ==",
+      "deprecated": "This version uses Atlas Device Sync, please install `realm@community` and read https://github.com/realm/realm-js/blob/main/DEPRECATION.md for more information.",
       "hasInstallScript": true,
       "dependencies": {
         "@realm/fetch": "^0.1.1",
@@ -29128,9 +29129,9 @@
       "peer": true
     },
     "realm": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-12.12.1.tgz",
-      "integrity": "sha512-xkTnkrLqm9ihowzUR4cXQFccZliZ3CAgZ4opIOObEhXmVAftz2InPccmkXg8qOpU611asTpfRBHqEMM+3eJLYg==",
+      "version": "12.13.1",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-12.13.1.tgz",
+      "integrity": "sha512-fAs70ZCBf1P7htVhOTrDMFHD6SzoGXVsALy6DpOPR6t0LXoK635cKxBMECX3bYdCgI7+riSfdoWXLA/7g5yTSQ==",
       "requires": {
         "@realm/fetch": "^0.1.1",
         "bson": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "promise-reflect": "^1.1.0",
     "react-native-uuid": "^2.0.1",
-    "realm": "^12.12.1"
+    "realm": "^12.13.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",


### PR DESCRIPTION
This is needed for the upcoming jump to RN75. Its backward compatible.

React Native >= v0.75.0