### PR TITLE
Realm 20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /coverage
 /.idea
 /reactNativeQueue.realm*
+/reactNativeQueue.v23*
 *.iml

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This means it's very crucial to respect to select the proper version and respect
 
 | Queue Version | Realm Version | React Native | Hermes Support |
 |---------------|---------------|--------------|----------------|
+| 3.0.0         | 20.1.0        | => 0.71.4    | Yes            |
 | 2.5.0         | 12.13.1       | => 0.71.4    | Yes            |
 | 2.4.0         | 12.6.1        | => 0.71.4    | Yes            |
 | 2.3.0         | 12.5.0        | => 0.71.4    | Yes            |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "promise-reflect": "^1.1.0",
         "react-native-uuid": "^2.0.1",
-        "realm": "^12.13.1"
+        "realm": "^20.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",
@@ -15646,10 +15646,9 @@
       "peer": true
     },
     "node_modules/realm": {
-      "version": "12.13.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-12.13.1.tgz",
-      "integrity": "sha512-fAs70ZCBf1P7htVhOTrDMFHD6SzoGXVsALy6DpOPR6t0LXoK635cKxBMECX3bYdCgI7+riSfdoWXLA/7g5yTSQ==",
-      "deprecated": "This version uses Atlas Device Sync, please install `realm@community` and read https://github.com/realm/realm-js/blob/main/DEPRECATION.md for more information.",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-20.1.0.tgz",
+      "integrity": "sha512-m/8y4Yad8x++ZL6BCRvsr+AGqxKJg2jErcXW2ZO48CwNYjw9YRERv4V0JWsLw9sFkzVZIw1e4u9I/Dd+hmMhzw==",
       "hasInstallScript": true,
       "dependencies": {
         "@realm/fetch": "^0.1.1",
@@ -28927,9 +28926,9 @@
       "peer": true
     },
     "realm": {
-      "version": "12.13.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-12.13.1.tgz",
-      "integrity": "sha512-fAs70ZCBf1P7htVhOTrDMFHD6SzoGXVsALy6DpOPR6t0LXoK635cKxBMECX3bYdCgI7+riSfdoWXLA/7g5yTSQ==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-20.1.0.tgz",
+      "integrity": "sha512-m/8y4Yad8x++ZL6BCRvsr+AGqxKJg2jErcXW2ZO48CwNYjw9YRERv4V0JWsLw9sFkzVZIw1e4u9I/Dd+hmMhzw==",
       "requires": {
         "@realm/fetch": "^0.1.1",
         "bson": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "promise-reflect": "^1.1.0",
     "react-native-uuid": "^2.0.1",
-    "realm": "^12.13.1"
+    "realm": "^20.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",


### PR DESCRIPTION
Realm is going through some stuff.

* They are removing the Atlas Sync and best to my memory that was for the offline/cloud sync of a Realm db. We never used that we leveraged Realm as a wrapper around DB for a queue system.
* Because of this they deprecated the package and it makes getting anything prior to v20 hard (as it marks it as deprecated)
* So this moves us to Realm v20