### PR TITLE
chore: fix github link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sourcetoad/react-native-queue/react-native-queue.git"
+    "url": "https://github.com/sourcetoad/react-native-queue.git"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
I clicked our Repo link on npmjs and it 404`d.